### PR TITLE
Handle MPD_RESPONSE_DURATION as float instead of int 

### DIFF
--- a/app/src/main/java/org/gateshipone/malp/mpdservice/mpdprotocol/MPDConnection.java
+++ b/app/src/main/java/org/gateshipone/malp/mpdservice/mpdprotocol/MPDConnection.java
@@ -1271,7 +1271,7 @@ public class MPDConnection {
             } else if (response.startsWith(MPDResponses.MPD_RESPONSE_ELAPSED_TIME)) {
                 status.setElapsedTime(Math.round(Float.valueOf(response.substring(MPDResponses.MPD_RESPONSE_ELAPSED_TIME.length()))));
             } else if (response.startsWith(MPDResponses.MPD_RESPONSE_DURATION)) {
-                status.setTrackLength(Integer.valueOf(response.substring(MPDResponses.MPD_RESPONSE_DURATION.length())));
+                status.setTrackLength(Math.round(Float.valueOf(response.substring(MPDResponses.MPD_RESPONSE_DURATION.length()))));
             } else if (response.startsWith(MPDResponses.MPD_RESPONSE_BITRATE)) {
                 status.setBitrate(Integer.valueOf(response.substring(MPDResponses.MPD_RESPONSE_BITRATE.length())));
             } else if (response.startsWith(MPDResponses.MPD_RESPONSE_AUDIO_INFORMATION)) {


### PR DESCRIPTION
It looks like "duration" is only returned by bleeding edge/unreleased MPD 0.20.  I built 0.20 and noticed when playing a track MALP crashes with 

java.lang.NumberFormatException: Invalid int: "135.466"
at
...
org.gateshipone.malp.mpdservice.mpdprotocol.MPDConnection.getCurrentServerStatus(MPDConnection.java:1274)

Here's an example of duration info returned by mpd 0.20:

duration: 135.466

So it can be handled as float just like MPD_RESPONSE_ELAPSED_TIME.
