### PR TITLE
Replace stop button with next button in compact notification

### DIFF
--- a/app/src/main/java/org/gateshipone/malp/application/background/NotificationManager.java
+++ b/app/src/main/java/org/gateshipone/malp/application/background/NotificationManager.java
@@ -218,7 +218,7 @@ public class NotificationManager implements CoverBitmapLoader.CoverBitmapListene
             mNotificationBuilder.addAction(stopActon);
             mNotificationBuilder.addAction(nextAction);
             NotificationCompat.MediaStyle notificationStyle = new NotificationCompat.MediaStyle();
-            notificationStyle.setShowActionsInCompactView(1, 2);
+            notificationStyle.setShowActionsInCompactView(1, 3);
             mNotificationBuilder.setStyle(notificationStyle);
 
             String title;


### PR DESCRIPTION
I don't see, why you would want to have a stop button always available. I much more often want to skip the current track instead.

Also, for some reason, I cannot expand the compact notification on the lock screen, forcing me to unlock the device to skip a track.