### PR TITLE
Add legal attribution, increase badge size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 ![Logo](https://raw.githubusercontent.com/gateship-one/malp/master/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png)
 # M.A.L.P. - Android MPD Client #
 
-[<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="60">](https://f-droid.org/app/org.gateshipone.malp)<a href="https://play.google.com/store/apps/details?id=org.gateshipone.malp"><img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" height="60"></a>
+[<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/app/org.gateshipone.malp)
+[<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="80">](https://play.google.com/store/apps/details?id=org.gateshipone.malp)
+
+Google Play and the Google Play logo are trademarks of Google Inc. 
 
 This whole project is licensed under the  **GPLv3 or later** license (see LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 # M.A.L.P. - Android MPD Client #
 
 [<img src="https://f-droid.org/badge/get-it-on.png" alt="Get it on F-Droid" height="80">](https://f-droid.org/app/org.gateshipone.malp)
-[<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" alt="Get it on Google Play" height="80">](https://play.google.com/store/apps/details?id=org.gateshipone.malp)
-
-Google Play and the Google Play logo are trademarks of Google Inc. 
 
 This whole project is licensed under the  **GPLv3 or later** license (see LICENSE)
 


### PR DESCRIPTION
See https://play.google.com/intl/en_us/badges/
The recommended height is 80 and now markdown format is used for both pictures