### PR TITLE
Fix parsing error messages sent by Quod Libet's MPD plugin

### DIFF
--- a/app/src/main/java/org/gateshipone/malp/mpdservice/mpdprotocol/MPDException.java
+++ b/app/src/main/java/org/gateshipone/malp/mpdservice/mpdprotocol/MPDException.java
@@ -53,7 +53,7 @@ public class MPDException extends Exception {
             // Parse the error message (s. https://www.musicpd.org/doc/protocol/response_syntax.html#failure_response_syntax)
             String substring;
             // Start with the [ErrorCode@Offset]
-            substring = error.substring(error.indexOf('[') + 1,error.lastIndexOf('@'));
+            substring = error.substring(error.indexOf('[') + 1,error.lastIndexOf('@') != -1 ? error.lastIndexOf('@') : error.lastIndexOf(']'));
             try {
                 mErrorCode = Integer.valueOf(substring);
             } catch (NumberFormatException e) {


### PR DESCRIPTION
* Example message that would crash M.A.L.P before:
  error=ACK [3] {password} Password incorrect